### PR TITLE
Add "duplicate" operation and register hotkeys for "duplicate" and "remove"

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,10 @@ Displays the `Edible Parameters` for the current selected `AtlasTexture`
 
 ![image](./README.IMG/04.png)
 
-Control|Description
-:-|:-
-`X`|`Remove` the selected `AtlasTexture`, only available for `temporarily` created AtlasTextures.
+Control|Description|Hotkey
+:-|:-|:-
+`◧`|`Duplicate` the selected `AtlasTexture` right below, only available for `temporarily` created AtlasTextures. |`Ctrl + D`
+`X`|`Remove` the selected `AtlasTexture`, only available for `temporarily` created AtlasTextures. |`Del`
 `Name`|Edit the `Name` of the selected `AtlasTexture`, only available for `temporarily` created AtlasTextures.
 `Region`|Edit the `Region` of the selected `AtlasTexture`.
 `Margin`|Edit the `Margin` of the selected `AtlasTexture`.
@@ -185,9 +186,10 @@ Avoid Existing (Smart)|区域被现有AtlasTextures占据的新AtlasTexture切�
 
 ![image](./README.IMG/04.png)
 
-控件|介绍
-:-|:-
-`X`|`删除`选定的`AtlasTexture`，仅适用于`临时`创建的AtlasTextures。
+控件|介绍|热键
+:-|:-|:-
+`◧`|`复制`选定的`AtlasTexture`到下方，仅适用于`临时`创建的AtlasTextures。|`Ctrl + D`
+`X`|`删除`选定的`AtlasTexture`，仅适用于`临时`创建的AtlasTextures。|`Del`
 `Name`|编辑所选`AtlasTexture`的`名称`。
 `Region`|编辑所选`AtlasTexture`的`Region`属性。
 `Margin`|编辑所选`AtlasTexture`的`Margin`属性。

--- a/addons/deyu_atlas_texture_creator_window/EditingAtlasTextureInfo.cs
+++ b/addons/deyu_atlas_texture_creator_window/EditingAtlasTextureInfo.cs
@@ -60,8 +60,8 @@ public class EditingAtlasTextureInfo
             dataResourcePath
         );
     }
-
-    public static EditingAtlasTextureInfo CreateEmpty(in Rect2 region, string textureName, in Rect2 margin, bool filterClip, IEnumerable<EditingAtlasTextureInfo> existingAtlasTextures)
+    
+    private static string GetNextNameCandidate(string textureName, IEnumerable<EditingAtlasTextureInfo> existingAtlasTextures)
     {
         var textureNameLower = textureName.ToLower();
         var existingAtlasTextureNamesLowerCase = existingAtlasTextures.Select(x => x.Name.ToLower()).ToHashSet();
@@ -74,6 +74,13 @@ public class EditingAtlasTextureInfo
         }
         while (existingAtlasTextureNamesLowerCase.Contains(nameCandidate));
 
+        return nameCandidate;
+    }
+
+    public static EditingAtlasTextureInfo CreateEmpty(in Rect2 region, string textureName, in Rect2 margin, bool filterClip, IEnumerable<EditingAtlasTextureInfo> existingAtlasTextures)
+    {
+        var nameCandidate = GetNextNameCandidate(textureName, existingAtlasTextures);
+
         var info =
             new EditingAtlasTextureInfo(null, region, margin, filterClip, null, null)
             {
@@ -82,6 +89,23 @@ public class EditingAtlasTextureInfo
             };
 
         return info;
+    }
+
+    public EditingAtlasTextureInfo Duplicate(string textureName, IEnumerable<EditingAtlasTextureInfo> existingAtlasTextures)
+    {
+        var nameCandidate = GetNextNameCandidate(textureName, existingAtlasTextures);
+        var rect = Region;
+        rect.Position += new Vector2(0.0f, rect.Size.Y);
+        return new EditingAtlasTextureInfo(null, 
+            rect,
+            Margin,
+            FilterClip,
+            nameCandidate,
+            m_ResourcePath
+        )
+        {
+            Modified = true,
+        };
     }
 
     public bool TrySetName(in string name)
@@ -140,7 +164,7 @@ public class EditingAtlasTextureInfo
                 };
             m_ResourcePath = GdPath.Combine(sourceTextureDirectory, $"{Name}.tres");
         }
-
+        
         m_BackingAtlasTexture.Region = Region;
         m_BackingAtlasTexture.Margin = Margin;
         m_BackingAtlasTexture.FilterClip = FilterClip;

--- a/addons/deyu_atlas_texture_creator_window/UnityAtlasTextureCreator.Section2.AtlasTextureMiniInspector.cs
+++ b/addons/deyu_atlas_texture_creator_window/UnityAtlasTextureCreator.Section2.AtlasTextureMiniInspector.cs
@@ -1,6 +1,7 @@
 ﻿#if TOOLS
 
 
+using System.Linq;
 using Godot;
 
 namespace DEYU.GDUtilities.UnityAtlasTextureCreatorUtility;
@@ -12,7 +13,8 @@ public partial class UnityAtlasTextureCreator
 
     [Export] private Label NewItemLabel { get; set; }
     [Export] private Button DeleteItemButton { get; set; }
-
+    [Export] private Button DuplicateItemButton { get; set; }
+    
     [Export, ExportSubgroup("AtlasTexture Mini Inspector Section/Inputs")] private LineEdit AtlasTextureNameInput { get; set; }
 
     [Export, ExportSubgroup("AtlasTexture Mini Inspector Section/Inputs/Region")]
@@ -139,7 +141,18 @@ public partial class UnityAtlasTextureCreator
             {
                 if (m_InspectingAtlasTextureInfo is null || !m_InspectingAtlasTextureInfo.IsTemp) return;
                 m_EditingAtlasTexture.Remove(m_InspectingAtlasTextureInfo);
-                m_InspectingAtlasTextureInfo = null;
+                m_InspectingAtlasTextureInfo = m_EditingAtlasTexture.Count > 0 ? m_EditingAtlasTexture.Last() : null;
+                UpdateControls();
+            }
+        );
+        RegButtonPressed(
+            DuplicateItemButton,
+            () =>
+            {
+                if (m_InspectingAtlasTextureInfo is null || !m_InspectingAtlasTextureInfo.IsTemp) return;
+                var newInfo = m_InspectingAtlasTextureInfo.Duplicate(m_InspectingTexName, m_EditingAtlasTexture);
+                m_EditingAtlasTexture.Add(newInfo);
+                m_InspectingAtlasTextureInfo = newInfo;
                 UpdateControls();
             }
         );
@@ -194,11 +207,13 @@ public partial class UnityAtlasTextureCreator
         if (atlasTextureInfo.IsTemp)
         {
             NewItemLabel.Show();
+            DuplicateItemButton.Show();
             DeleteItemButton.Show();
         }
         else
         {
             NewItemLabel.Hide();
+            DuplicateItemButton.Hide();
             DeleteItemButton.Hide();
         }
 

--- a/addons/deyu_atlas_texture_creator_window/atlas_texture_creator_window.tscn
+++ b/addons/deyu_atlas_texture_creator_window/atlas_texture_creator_window.tscn
@@ -1,8 +1,23 @@
-[gd_scene load_steps=2 format=3 uid="uid://deqj2mqv43cr8"]
+[gd_scene load_steps=6 format=3 uid="uid://deqj2mqv43cr8"]
 
 [ext_resource type="Script" path="res://addons/deyu_atlas_texture_creator_window/UnityAtlasTextureCreator.cs" id="1_mppxe"]
 
-[node name="atlas_texture_creator_window" type="Control" node_paths=PackedStringArray("SnapModeButton", "AtlasTextureSlicerButton", "ScanAtlasInFolderButton", "ScanAtlasInProjectButton", "EditDrawer", "ZoomInButton", "ZoomResetButton", "ZoomOutButton", "VScroll", "HScroll", "MiniInspectorWindow", "NewItemLabel", "DeleteItemButton", "AtlasTextureNameInput", "AtlasTextureRegionXInput", "AtlasTextureRegionYInput", "AtlasTextureRegionWInput", "AtlasTextureRegionHInput", "AtlasTextureMarginXInput", "AtlasTextureMarginYInput", "AtlasTextureMarginWInput", "AtlasTextureMarginHInput", "AtlasTextureFilterClipInput", "DiscardButton", "SaveAndUpdateButton", "SlicerMenu", "SlicerTypeSelection", "PreservationMethodSelection", "ExecuteSliceButton", "NewAtlasTextureMarginXInput", "NewAtlasTextureMarginYInput", "NewAtlasTextureMarginWInput", "NewAtlasTextureMarginHInput", "FilterClip", "CellSizeGroup", "CellSize_PixelSizeX", "CellSize_PixelSizeY", "CellSize_OffsetX", "CellSize_OffsetY", "CellSize_PaddingX", "CellSize_PaddingY", "CellSize_KeepEmptyRects", "CellCountGroup", "CellCount_ColumnRowX", "CellCount_ColumnRowY", "CellCount_OffsetX", "CellCount_OffsetY", "CellCount_PaddingX", "CellCount_PaddingY", "CellCount_KeepEmptyRects")]
+[sub_resource type="InputEventKey" id="InputEventKey_3ptgg"]
+device = -1
+ctrl_pressed = true
+keycode = 68
+
+[sub_resource type="Shortcut" id="Shortcut_sqdp3"]
+events = [SubResource("InputEventKey_3ptgg")]
+
+[sub_resource type="InputEventKey" id="InputEventKey_ih8ak"]
+device = -1
+keycode = 4194312
+
+[sub_resource type="Shortcut" id="Shortcut_6h25o"]
+events = [SubResource("InputEventKey_ih8ak")]
+
+[node name="atlas_texture_creator_window" type="Control" node_paths=PackedStringArray("SnapModeButton", "AtlasTextureSlicerButton", "ScanAtlasInFolderButton", "ScanAtlasInProjectButton", "EditDrawer", "ZoomInButton", "ZoomResetButton", "ZoomOutButton", "VScroll", "HScroll", "MiniInspectorWindow", "NewItemLabel", "DeleteItemButton", "DuplicateItemButton", "AtlasTextureNameInput", "AtlasTextureRegionXInput", "AtlasTextureRegionYInput", "AtlasTextureRegionWInput", "AtlasTextureRegionHInput", "AtlasTextureMarginXInput", "AtlasTextureMarginYInput", "AtlasTextureMarginWInput", "AtlasTextureMarginHInput", "AtlasTextureFilterClipInput", "DiscardButton", "SaveAndUpdateButton", "SlicerMenu", "SlicerTypeSelection", "PreservationMethodSelection", "ExecuteSliceButton", "NewAtlasTextureMarginXInput", "NewAtlasTextureMarginYInput", "NewAtlasTextureMarginWInput", "NewAtlasTextureMarginHInput", "FilterClip", "CellSizeGroup", "CellSize_PixelSizeX", "CellSize_PixelSizeY", "CellSize_OffsetX", "CellSize_OffsetY", "CellSize_PaddingX", "CellSize_PaddingY", "CellSize_KeepEmptyRects", "CellCountGroup", "CellCount_ColumnRowX", "CellCount_ColumnRowY", "CellCount_OffsetX", "CellCount_OffsetY", "CellCount_PaddingX", "CellCount_PaddingY", "CellCount_KeepEmptyRects")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -23,6 +38,7 @@ HScroll = NodePath("VBoxContainer/EditorViewport/Painter/HScrollBar")
 MiniInspectorWindow = NodePath("VBoxContainer/EditorViewport/AtlasTextureMiniInspector")
 NewItemLabel = NodePath("VBoxContainer/EditorViewport/AtlasTextureMiniInspector/MarginContainer/VBoxContainer/HBoxContainer/NewIndicator")
 DeleteItemButton = NodePath("VBoxContainer/EditorViewport/AtlasTextureMiniInspector/MarginContainer/VBoxContainer/HBoxContainer/DeleteButton")
+DuplicateItemButton = NodePath("VBoxContainer/EditorViewport/AtlasTextureMiniInspector/MarginContainer/VBoxContainer/HBoxContainer/DuplicateButton")
 AtlasTextureNameInput = NodePath("VBoxContainer/EditorViewport/AtlasTextureMiniInspector/MarginContainer/VBoxContainer/GridContainer/NameEdit")
 AtlasTextureRegionXInput = NodePath("VBoxContainer/EditorViewport/AtlasTextureMiniInspector/MarginContainer/VBoxContainer/GridContainer/GridContainer/XEdit")
 AtlasTextureRegionYInput = NodePath("VBoxContainer/EditorViewport/AtlasTextureMiniInspector/MarginContainer/VBoxContainer/GridContainer/GridContainer/YEdit")
@@ -210,9 +226,16 @@ horizontal_alignment = 1
 layout_mode = 2
 size_flags_horizontal = 3
 
+[node name="DuplicateButton" type="Button" parent="VBoxContainer/EditorViewport/AtlasTextureMiniInspector/MarginContainer/VBoxContainer/HBoxContainer"]
+custom_minimum_size = Vector2(30, 0)
+layout_mode = 2
+shortcut = SubResource("Shortcut_sqdp3")
+text = "◧"
+
 [node name="DeleteButton" type="Button" parent="VBoxContainer/EditorViewport/AtlasTextureMiniInspector/MarginContainer/VBoxContainer/HBoxContainer"]
 custom_minimum_size = Vector2(30, 0)
 layout_mode = 2
+shortcut = SubResource("Shortcut_6h25o")
 text = "X"
 
 [node name="GridContainer" type="GridContainer" parent="VBoxContainer/EditorViewport/AtlasTextureMiniInspector/MarginContainer/VBoxContainer"]


### PR DESCRIPTION
![hotkey](https://github.com/Delsin-Yu/GD-AtlasTexture-Creator/assets/33864304/9fb02e37-ceeb-46be-8b9b-cea03a26eab9)

- Add `duplicate` operation: With `temporarily` created `AtlasTexture` selected, press `◧` button in `MiniInspector` or press `Ctrl + D` to create a copy of `AtlasTexture` just below current selection.
- Bind `Del` hotkey to `remove` operation.
- When created a bunch of `AtlasTexture`s, try to leave focus on the last `AtlasTexture` after `remove` operation for continually deletion.
